### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release_binaries.yml
+++ b/.github/workflows/release_binaries.yml
@@ -1,0 +1,117 @@
+name: Upload Release Binaries
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/linuxkit/linuxkit
+
+    - name: Set RELEASE_VERSION env
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.RELEASE_VERSION }}
+        release_name: ${{ env.RELEASE_VERSION }}
+        draft: false
+        prerelease: false
+
+    - uses: nick-invision/persist-action-data@v1
+      with:
+        data: ${{ steps.create_release.outputs.upload_url }}
+        variable: RELEASE_UPLOAD_URL
+
+  build:
+    name: Build & Upload
+    needs: release
+    strategy:
+      matrix:
+        arch:
+          - amd64-linux
+          - arm64-linux
+          - s390x-linux
+          - amd64-darwin
+          - amd64-windows.exe
+
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.13.4
+      id: go
+
+    - name: Check out code
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/linuxkit/linuxkit
+
+    - name: Set path
+      run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      env:
+         GOPATH: ${{runner.workspace}}
+
+    - name: Get pre-requisites
+      run: |
+            go get -u golang.org/x/lint/golint
+            go get -u github.com/gordonklaus/ineffassign
+      env:
+        GOPATH: ${{runner.workspace}}
+
+    - name: Lint
+      run: |
+        make local-check
+      env:
+        GOPATH: ${{runner.workspace}}
+
+    - name: Build
+      run: |
+        make LOCAL_TARGET=bin/linuxkit-${{matrix.arch}} local-build
+      env:
+        GOPATH: ${{runner.workspace}}
+
+    - name: Checksum
+      run: cd bin && sha256sum linuxkit-${{matrix.arch}} > linuxkit-${{matrix.arch}}.SHA256SUM
+
+    - name: Test
+      run: make local-test
+      env:
+        GOPATH: ${{runner.workspace}}
+
+    - uses: nick-invision/persist-action-data@v1
+      with:
+        retrieve_variables: RELEASE_UPLOAD_URL
+
+    - name: Upload binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ env.RELEASE_UPLOAD_URL }}
+        asset_path: ./bin/linuxkit-${{matrix.arch}}
+        asset_name: linuxkit-${{matrix.arch}}
+        asset_content_type: application/octet-stream
+
+    - name: Upload SHA256 checkum
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ env.RELEASE_UPLOAD_URL }}
+        asset_path: ./bin/linuxkit-${{matrix.arch}}.SHA256SUM
+        asset_name: linuxkit-${{matrix.arch}}.SHA256SUM
+        asset_content_type: text/plain


### PR DESCRIPTION
**- What I did**

add a new github action workflow to release binaries whenever a tag is pushed

**- How to verify it**

push a new tag and wait release workflow finish

refer: 
* https://github.com/vouch-opensource/linuxkit/actions/runs/605570197
* https://github.com/vouch-opensource/linuxkit/releases/tag/1f93eab

**- Description for the changelog**

add release workflow