### PR TITLE
feat: adds multiple formats for logwrite logs

### DIFF
--- a/pkg/logwrite/logwrite.go
+++ b/pkg/logwrite/logwrite.go
@@ -73,8 +73,8 @@ func NewLogFile(dir, name string) (*LogFile, error) {
 }
 
 // Write appends a message to the log file
-func (l *LogFile) Write(m *LogMessage, formatLog string) error {
-	s := m.String(formatLog) + "\n"
+func (l *LogFile) Write(m *LogMessage, logFormat string) error {
+	s := m.String(logFormat) + "\n"
 	_, err := io.WriteString(l.File, s)
 	if err == nil {
 		l.BytesWritten += len(s)


### PR DESCRIPTION
**- What I did**
Added a new flag for `logwrite` package, which allows the user to choose the format that fits better his application

**- How to verify it**
Create an image with
```yml
  - name: write-and-rotate-logs
    image: linuxkit/logwrite:hash
    command: ["/usr/bin/logwrite", "-log-format", "raw"]  # valid formats are time-and-source, time, source and raw
```

At first, I tried creating the flag with a boolean value for it, but go was not parsing it correctly, so changed to strings and also added multiple valid formats. With booleans only the default (time, source and message) and raw (only message) behaviours would be supported.

